### PR TITLE
Pass the close function to promiseResolve/callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,4 +49,4 @@ You can see full tutorial and document on [x0popup](http://gao-sun.github.io/x0p
 
 Please leave an issue if you find any bugs, I will fix it ASAP.
 
-If you have any new ideas, feel free to make a pull request and wait for accpetance.
+If you have any new ideas, feel free to make a pull request and wait for acceptance.

--- a/src/js/x0popup.js
+++ b/src/js/x0popup.js
@@ -46,7 +46,7 @@ x0popup = x0p = function() {
 		config.title = arguments[0];
 		(arguments[1] != undefined) && (config.text = arguments[1]);
 		(arguments[2] != undefined) && (config.type = arguments[2]);
-		if(arguments[3] != undefined) { 
+		if(arguments[3] != undefined) {
 			(typeof(arguments[3]) == 'boolean') ? (config.overlayAnimation = arguments[3]) : (callback = arguments[3]);
 		}
 	} else { // specific
@@ -62,7 +62,7 @@ x0popup = x0p = function() {
 	*	Icon Priority: icon > type
 	*	Input Type Priority: inputType > type
 	*	Buttons: buttons > showCancelButton > type
-	**/	
+	**/
 	var str = '';
 	var textOnly = (config.icon == null && (config.type == 'text' || config.type == 'input'));
 	var inputType = (config.inputType != null ? config.inputType : (config.type == 'input' ? 'text' : null));
@@ -229,7 +229,7 @@ x0popup = x0p = function() {
 			// Update default index
 			(buttons[i].default == true) && (defaultIndex = i);
 		}
-		
+
 		if(config.keyResponse && buttons.length > 0) {
 			var lastButton = document.getElementById('x0p-button-' + (buttons.length - 1));
 
@@ -304,11 +304,12 @@ x0popup = x0p = function() {
 
 		var inputText = (inputDOM == null ? null : inputDOM.value);
 
-		(callback != null) && (callback(buttonType, inputText));
+		(callback != null) && (callback(buttonType, inputText, close));
 
 		promiseResolve({
-			button: buttonType, 
-			text: inputText
+			button: buttonType,
+			text: inputText,
+			close: close
 		});
 	}
 


### PR DESCRIPTION
- Add the `close` function in the promiseResolve and callback function. This allows closing the popup manually when using an async operation. From what I can tell, the only way to close the current popup is to load a new x0popup window.
- Fix a small spelling mistake at the end of the README.
- Atom.io removed some trailing spaces automatically.